### PR TITLE
Implements global command palette

### DIFF
--- a/docs/Tasks.csv
+++ b/docs/Tasks.csv
@@ -1,0 +1,53 @@
+Title|Body|Labels|Milestone
+M0: App shell & layout|- Setup Tauri/React app\n- Main window layout\n- Docked panels\n- Status bar\n- Resizable panes|required,ux,infra|M0 - App Shell
+M0: Top-level menu system|- File/Edit/View menus\n- Profile actions\n- Connection actions|required,ux|M0 - App Shell
+M0: Sidebar navigation|- Profiles\n- Frames\n- Signals\n- Columns\n- Filters\n- TX|required,ux|M0 - App Shell
+M0: Command palette|- VSCode-style palette\n- Action registry\n- Keyboard shortcuts|required,ux|M0 - App Shell
+
+
+M1: Profile schema finalization,"- Freeze v1 schema\n- Versioning rules\n- Migration plan","required,profile","M1 – Profile Editor"
+M1: Profile loader & validator,"- JSON schema validation\n- Error diagnostics\n- Warnings","required,profile","M1 – Profile Editor"
+M1: Profile editor shell,"- Tree-based navigation\n- Section switching\n- Dirty state handling","required,profile-editor,ux","M1 – Profile Editor"
+M1: Signal editor UI,"- Byte/bit selector\n- Payload preview (0–64 bytes)\n- Factor & unit helpers","required,profile-editor","M1 – Profile Editor"
+M1: Derived field editor,"- Source selection\n- Expression editor\n- Dependency validation","required,profile-editor","M1 – Profile Editor"
+M1: Column editor,"- Source type selection\n- Drag/drop ordering\n- Visibility toggle","required,profile-editor","M1 – Profile Editor"
+M1: Filter editor (capture & display)," - Frame-level filters\n- Signal/derived filters\n- Expression filters\n- Test preview","required,profile-editor,filtering","M1 – Profile Editor"
+M1: TX frame editor,"- Form builder UI\n- Encode preview\n- Validation rules","required,profile-editor,tx","M1 – Profile Editor"
+M1: Live JSON preview,"- Read-only JSON view\n- Highlight active section","best-to-have,profile-editor","M1 – Profile Editor"
+M1: Undo/redo support,"- History stack\n- Keyboard shortcuts","best-to-have,profile-editor","M1 – Profile Editor"
+
+
+M2: Runtime profile engine,"- Load active profile\n- Resolve signals\n- Resolve derived fields","required,profile","M2 – Runtime Engine"
+M2: Expression engine,"- Safe evaluation\n- Dependency resolution\n- Error reporting","required,expression","M2 – Runtime Engine"
+M2: Signal decoder,"- Bit extraction\n- Factor/unit application\n- Endianness handling","required,decoder","M2 – Runtime Engine"
+M2: Derived field evaluator,"- Expression evaluation\n- Type handling\n- Caching","required,derived-field","M2 – Runtime Engine"
+M2: TX frame encoder,"- Payload construction\n- Validation\n- Error reporting","required,tx,encoder","M2 – Runtime Engine"
+
+
+M3: CAN bridge abstraction,"- Transport interface\n- Direction RX/TX","required,core,bridge","M3 – CAN Bridge"
+M3: SocketCAN support,"- Native Linux support\n- CAN-FD flags","required,core,can-fd","M3 – CAN Bridge"
+M3: WebSocket JSON bridge,"- Connect to daemon\n- Reconnect logic","required,core,bridge","M3 – CAN Bridge"
+M3: TCP JSONL bridge,"- Streaming support\n- Error recovery","optional,core,bridge","M3 – CAN Bridge"
+M3: gRPC bridge,"- Proto definitions\n- Streaming APIs","optional,core,bridge","M3 – CAN Bridge"
+M3: Mock bridge,"- Simulated frames\n- Configurable patterns","optional,core,bridge","M3 – CAN Bridge"
+
+
+
+M4: TX scheduler,"- Periodic send\n- Burst send\n- Stop/start","required,tx","M4 – Simulation"
+M4: Simulation controls,"- Play/pause\n- Rate control","optional,simulation","M4 – Simulation"
+M4: TX logging,"- Sent frame log\n- Export sent frames","optional,tx,export","M4 – Simulation"
+
+
+M5: Frame store,"- Ring buffer\n- Pause capture\n- Clear/reset","required,core","M5 – Filtering & Analysis"
+M5: Capture filtering,"- Frame-level predicates\n- Drop metrics","required,filtering","M5 – Filtering & Analysis"
+M5: Display filtering,"- Expression-based filtering\n- Live toggle","required,filtering,ui","M5 – Filtering & Analysis"
+M5: Table virtualization,"- Large dataset support","required,ui","M5 – Filtering & Analysis"
+M5: Column customization,"- Show/hide columns\n- Reorder columns\n- Resize columns","required,ui,column","M5 – Filtering & Analysis"
+M5: Export functionality,"- CSV export\n- JSONL export","required,export","M5 – Filtering & Analysis"
+
+
+M6: Theme system,"- Dark/light\n- Persist preference","optional,ux","M6 – Polish"
+M6: Metrics & stats,"- RX/TX counters\n- Latency","optional,observability","M6 – Polish"
+M6: Sample demo profiles,"- Classic CAN\n- CAN-FD","required,docs","M6 – Polish"
+M6: DBC importer,"- Basic DBC to JSON","best-to-have,profile","M6 – Polish"
+M6: User documentation,"- User guide\n- Profile schema reference","required,docs","M6 – Polish"

--- a/docs/issue.sh
+++ b/docs/issue.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+REPO="pennowtech/rusty-can-studio"
+
+tail -n +2 Tasks.csv | while IFS='|' read -r title body labels milestone; do
+  gh issue create \
+    --repo "$REPO" \
+    --title "$title" \
+    --body "$body" \
+    --label "$labels" \
+    --milestone "$milestone"
+done

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    // can_sim_lib::run()
+    tauri_app_lib::run();
 }

--- a/src/commands/CommandPalette.tsx
+++ b/src/commands/CommandPalette.tsx
@@ -1,0 +1,59 @@
+/**
+ * CommandPalette.tsx
+ * ------------------------------------------------------------
+ * Global command palette component.
+ *
+ * RESPONSIBILITY
+ * - Provides a searchable command interface
+ * - Allows quick access to application commands
+ * - Integrates with global state to execute commands
+ *
+ * CONVENTIONS
+ * - Uses Zustand for state management
+ * - Uses Dialog and Command components for UI
+ * - Commands are registered in commandRegistry
+ *
+ * HOW TO USE
+ * - Import and include <CommandPalette /> in the application root
+ * - Use useCommandPaletteStore to control visibility
+ * - Define commands in commandRegistry(registry.ts) with appropriate handlers
+ * ------------------------------------------------------------
+ */
+
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+
+import { commandRegistry } from "@/commands/registry";
+import { useCommandPaletteStore } from "@/store/commandPaletteStore";
+import { useAppStore } from "@/store/appShellStore";
+
+export function CommandPalette() {
+  const { open, closePalette } = useCommandPaletteStore();
+  const setView = useAppStore((s) => s.setView);
+
+  return (
+    <Dialog open={open} onOpenChange={closePalette}>
+      <DialogContent className="p-0">
+        <Command>
+          <CommandInput placeholder="Type a command…" />
+          <CommandEmpty>No commands found.</CommandEmpty>
+
+          <CommandGroup heading="Commands">
+            {commandRegistry.map((cmd) => (
+              <CommandItem
+                key={cmd.id}
+                value={[cmd.title, ...(cmd.keywords ?? [])].join(" ")}
+                onSelect={() => {
+                  cmd.handler({ setView });
+                  closePalette();
+                }}
+              >
+                {cmd.title}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,0 +1,41 @@
+/**
+ * registry.ts
+ * ------------------------------------------------------------
+ * Command registry for the application.
+ *
+ * RESPONSIBILITY
+ * - Defines available commands for the command palette.
+ * - Each command includes metadata and a handler function.
+ * - Commands interact with the application state via CommandContext.
+ *
+ * CONVENTIONS
+ * - Commands should be self-contained.
+ * - CommandContext should expose only necessary methods.
+ * - Commands should not directly manipulate UI components.
+ */
+
+import { AppCommand } from "./types";
+
+export const commandRegistry: AppCommand[] = [
+  {
+    id: "view.monitor",
+    title: "View: CAN Monitor",
+    category: "View",
+    keywords: ["monitor", "can", "rx"],
+    handler: ({ setView }) => setView("monitor"),
+  },
+  {
+    id: "view.simulator",
+    title: "View: CAN Simulator",
+    category: "View",
+    keywords: ["tx", "sim"],
+    handler: ({ setView }) => setView("simulator"),
+  },
+  {
+    id: "view.profileEditor",
+    title: "View: Profile Editor",
+    category: "View",
+    keywords: ["profile", "editor"],
+    handler: ({ setView }) => setView("profile-editor"),
+  },
+];

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,28 @@
+/**
+ * types.ts
+ * ------------------------------------------------------------
+ *  Define types for application commands
+ *
+ * RESPONSIBILITY
+ * - CommandContext provides methods to manipulate app state
+ * - AppCommand defines the structure of a command
+ * - Commands can be run with access to the CommandContext
+ *
+ * CONVENTIONS
+ * - Commands should be self-contained
+ * - CommandContext should expose only necessary methods
+ * - Commands should not directly manipulate UI components
+ */
+
+export type CommandContext = {
+  setView: (view: any) => void;
+};
+
+export type AppCommand = {
+  id: string;
+  title: string;
+  category?: string;
+  keywords?: string[];
+  shortcut?: string;
+  handler: (ctx: CommandContext) => void;
+};

--- a/src/commands/useCommandPaletteHotkey.ts
+++ b/src/commands/useCommandPaletteHotkey.ts
@@ -1,0 +1,38 @@
+/**
+ * useCommandPaletteHotkey.ts
+ * ------------------------------------------------------------
+ * Adds a global keyboard shortcut (Ctrl+Shift+P or Cmd+Shift+P) to open the command palette.
+ *
+ * RESPONSIBILITY
+ * - Listens for specific keyboard events.
+ * - Opens the command palette when the shortcut is detected.
+ *
+ * CONVENTIONS
+ * - Uses React's useEffect to manage event listeners.
+ * - Detects platform to differentiate between Ctrl and Cmd keys.
+ * - Relies on the command palette store for state management.
+ *
+ * HOW TO USE
+ * - Import and call this hook in a top-level component (e.g., App component).
+ * - Ensure the command palette store is properly set up.
+ */
+import { useEffect } from "react";
+import { useCommandPaletteStore } from "@/store/commandPaletteStore";
+
+export function useCommandPaletteHotkey() {
+  const open = useCommandPaletteStore((s) => s.openPalette);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const isMac = navigator.platform.includes("Mac");
+
+      if ((isMac && e.metaKey && e.shiftKey && e.key === "P") || (!isMac && e.ctrlKey && e.shiftKey && e.key === "P")) {
+        e.preventDefault();
+        open();
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import * as React from "react"
+import { type DialogProps } from "@radix-ui/react-dialog"
+import { Command as CommandPrimitive } from "cmdk"
+import { Search } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+Command.displayName = CommandPrimitive.displayName
+
+const CommandDialog = ({ children, ...props }: DialogProps) => {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden p-0">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  </div>
+))
+
+CommandInput.displayName = CommandPrimitive.Input.displayName
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    {...props}
+  />
+))
+
+CommandList.displayName = CommandPrimitive.List.displayName
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-sm"
+    {...props}
+  />
+))
+
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+
+CommandGroup.displayName = CommandPrimitive.Group.displayName
+
+const CommandSeparator = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 h-px bg-border", className)}
+    {...props}
+  />
+))
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      className
+    )}
+    {...props}
+  />
+))
+
+CommandItem.displayName = CommandPrimitive.Item.displayName
+
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+CommandShortcut.displayName = "CommandShortcut"
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/src/store/commandPaletteStore.ts
+++ b/src/store/commandPaletteStore.ts
@@ -1,0 +1,33 @@
+/**
+ * commandPaletteStore.ts
+ * ------------------------------------------------------------
+ * Command palette state store.
+ *
+ * RESPONSIBILITY
+ * - Manages the open/closed state of the command palette.
+ * - Provides methods to open and close the palette.
+ *
+ * CONVENTIONS
+ * - Zustand store
+ * - No derived or computed state
+ * - Pure UI concerns only
+ *
+ * HOW TO USE
+ * - Import the store using `useCommandPaletteStore`.
+ * - Call `openPalette` to open the command palette.
+ * - Call `closePalette` to close the command palette.
+ */
+
+import { create } from "zustand";
+
+type CommandPaletteState = {
+  open: boolean;
+  openPalette: () => void;
+  closePalette: () => void;
+};
+
+export const useCommandPaletteStore = create<CommandPaletteState>((set) => ({
+  open: false,
+  openPalette: () => set({ open: true }),
+  closePalette: () => set({ open: false }),
+}));


### PR DESCRIPTION
Adds a global command palette accessible via Ctrl+Shift+P (Cmd+Shift+P on macOS).

- Enables quick access to application commands.
- Registers available commands.
- Provides a searchable interface.

