### PR TITLE
Add help screens and command shortcuts

### DIFF
--- a/src/app/MainView.tsx
+++ b/src/app/MainView.tsx
@@ -27,6 +27,8 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { commandRegistry } from "@/commands/registry";
+import { displayShortcut, formatShortcutFromEvent, shortcutConflicts, useShortcutStore } from "@/commands/shortcutStore";
 import { useTheme } from "@/components/ThemeProvider";
 import type { Theme, ThemeDensity, ThemePalette } from "@/components/ThemeProvider";
 import { HelpShell } from "@/components/help-system/HelpShell";
@@ -34,6 +36,7 @@ import { useAppStore } from "@/store/appShellStore";
 import { useConnectionStore } from "@/store/connectionStore";
 import { ProfileMainShell } from "@/profile-editor/ProfileMainShell";
 import { useState } from "react";
+import { AlertTriangle, Info, Keyboard, Monitor, Palette, RotateCcw, Rows3, ShieldCheck } from "lucide-react";
 // import { EditorShell } from "@/editor/EditorShell";
 
 function SettingsView() {
@@ -207,6 +210,148 @@ function SettingsView() {
   );
 }
 
+function AboutView() {
+  const setView = useAppStore((s) => s.setView);
+  const { palette, density } = useTheme();
+
+  return (
+    <div className="h-full overflow-auto bg-muted/20 p-6">
+      <div className="mx-auto max-w-5xl space-y-5">
+        <section className="overflow-hidden rounded-xl border bg-background shadow-sm">
+          <div className="grid gap-0 lg:grid-cols-[1.2fr_0.8fr]">
+            <div className="p-8">
+              <Badge variant="outline" className="mb-4">Version 0.1.0</Badge>
+              <h1 className="text-3xl font-semibold tracking-tight">Rusty CAN Studio</h1>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+                A desktop workbench for CAN-FD capture, profile-driven decoding, loaded trace inspection, display filtering, and transmit preparation.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-2">
+                <Button onClick={() => setView("monitor")}>Open Monitor</Button>
+                <Button variant="outline" onClick={() => setView("help")}>Open Help</Button>
+              </div>
+            </div>
+            <div className="border-t bg-[radial-gradient(circle_at_20%_20%,hsl(var(--primary)/0.18),transparent_32%),linear-gradient(135deg,hsl(var(--muted)),hsl(var(--background)))] p-6 lg:border-l lg:border-t-0">
+              <div className="grid gap-3">
+                {[
+                  ["Active palette", palette],
+                  ["Density", density],
+                  ["Profile format", "JSON schema profiles"],
+                  ["Trace source", "Live capture or loaded log"],
+                ].map(([label, value]) => (
+                  <div key={label} className="rounded-lg border bg-background/80 p-3">
+                    <div className="text-[11px] uppercase text-muted-foreground">{label}</div>
+                    <div className="mt-1 text-sm font-medium">{value}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {[
+            { icon: Monitor, title: "Monitor", text: "Sticky trace headers, display filters, decoded preview, context copy, and transmit staging." },
+            { icon: Rows3, title: "Profiles", text: "Visual editing for service, payload header, attributes, operations, and payload fields." },
+            { icon: Palette, title: "Themes", text: "Selectable color palettes and density modes for comfortable, compact, or dense workflows." },
+            { icon: ShieldCheck, title: "Help", text: "Searchable documentation, callouts, shortcuts, and workflow notes are available from Help." },
+          ].map((item) => (
+            <Card key={item.title} className="rounded-xl">
+              <CardHeader className="pb-2">
+                <item.icon className="h-5 w-5 text-primary" />
+                <CardTitle className="text-sm">{item.title}</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">{item.text}</CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ShortcutsView() {
+  const shortcuts = useShortcutStore((s) => s.shortcuts);
+  const setShortcut = useShortcutStore((s) => s.setShortcut);
+  const resetShortcut = useShortcutStore((s) => s.resetShortcut);
+  const resetAllShortcuts = useShortcutStore((s) => s.resetAllShortcuts);
+  const conflicts = shortcutConflicts(shortcuts);
+  const groupedCommands = commandRegistry.reduce<Record<string, typeof commandRegistry>>((groups, command) => {
+    const category = command.category ?? "Commands";
+    groups[category] ??= [];
+    groups[category].push(command);
+    return groups;
+  }, {});
+
+  return (
+    <div className="h-full overflow-auto p-6">
+      <div className="mx-auto max-w-5xl space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <Keyboard className="h-5 w-5 text-primary" />
+              <h1 className="text-lg font-semibold">Keyboard shortcuts</h1>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">Click a shortcut field and press the new key combination. Changes are saved immediately.</p>
+          </div>
+          <Button variant="outline" onClick={resetAllShortcuts}>
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Reset all
+          </Button>
+        </div>
+
+        {conflicts.size > 0 && (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-300">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>Some shortcuts are assigned to more than one command. Resolve highlighted rows before relying on those shortcuts.</div>
+          </div>
+        )}
+
+        <div className="grid gap-4">
+          {Object.entries(groupedCommands).map(([category, commands]) => (
+            <Card key={category} className="rounded-xl">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">{category}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {commands.map((command) => {
+                  const hasConflict = conflicts.has(command.id);
+                  return (
+                    <div key={command.id} className={`grid gap-3 rounded-lg border p-3 md:grid-cols-[minmax(0,1fr)_220px_auto] ${hasConflict ? "border-amber-500/60 bg-amber-500/10" : "bg-muted/20"}`}>
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium">{command.title}</div>
+                        {command.description && <div className="mt-0.5 text-xs text-muted-foreground">{command.description}</div>}
+                      </div>
+                      <Input
+                        readOnly
+                        value={displayShortcut(shortcuts, command.id)}
+                        placeholder="No shortcut"
+                        className="font-mono text-xs"
+                        onKeyDown={(event) => {
+                          event.preventDefault();
+                          const nextShortcut = formatShortcutFromEvent(event.nativeEvent);
+                          if (nextShortcut) setShortcut(command.id, nextShortcut);
+                        }}
+                      />
+                      <Button variant="ghost" size="sm" onClick={() => resetShortcut(command.id)}>
+                        Reset
+                      </Button>
+                    </div>
+                  );
+                })}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <div className="flex items-start gap-2 rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+          <Info className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>Shortcuts are stored locally for this desktop app installation. The command panel shows the same saved shortcuts.</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function MainView() {
   const view = useAppStore((s) => s.view);
 
@@ -229,6 +374,12 @@ export function MainView() {
 
     case "help":
       return <HelpShell />;
+
+    case "shortcuts":
+      return <ShortcutsView />;
+
+    case "about":
+      return <AboutView />;
 
     default:
       return null;

--- a/src/app/TopMenuBar.tsx
+++ b/src/app/TopMenuBar.tsx
@@ -9,7 +9,7 @@ import {
 import { useAppStore } from "@/store/appShellStore";
 import { useTheme } from "@/components/ThemeProvider";
 import { Button } from "@/components/ui/button";
-import { Command, HelpCircle, Settings } from "lucide-react";
+import { Command, HelpCircle } from "lucide-react";
 import { useCommandPaletteStore } from "@/store/commandPaletteStore";
 import { useConnectDialogStore } from "@/store/canConnectDialogStore";
 import { useUiStore } from "@/store/uiStore";
@@ -30,10 +30,6 @@ export function TopMenuBar() {
       <div className="flex items-center gap-1 px-2">
         <Button variant="ghost" size="icon" onClick={openPalette} title="Command Palette (Ctrl+Shift+P)">
           <Command className="h-4 w-4" />
-        </Button>
-
-        <Button variant="ghost" size="icon" onClick={() => setView("settings")} title="Settings">
-          <Settings className="h-4 w-4" />
         </Button>
       </div>
 
@@ -84,10 +80,10 @@ export function TopMenuBar() {
           <MenubarTrigger>Help</MenubarTrigger>
           <MenubarContent>
             <MenubarItem onClick={() => setView("help")}>Open Help</MenubarItem>
-            <MenubarItem>Documentation</MenubarItem>
-            <MenubarItem>Keyboard Shortcuts</MenubarItem>
+            <MenubarItem onClick={() => setView("help")}>Documentation</MenubarItem>
+            <MenubarItem onClick={() => setView("shortcuts")}>Keyboard Shortcuts</MenubarItem>
             <MenubarSeparator />
-            <MenubarItem>About</MenubarItem>
+            <MenubarItem onClick={() => setView("about")}>About</MenubarItem>
           </MenubarContent>
         </MenubarMenu>
       </Menubar>

--- a/src/commands/CommandPalette.tsx
+++ b/src/commands/CommandPalette.tsx
@@ -1,69 +1,84 @@
-/**
- * CommandPalette.tsx
- * ------------------------------------------------------------
- * Global command palette component.
- *
- * RESPONSIBILITY
- * - Provides a searchable command interface
- * - Allows quick access to application commands
- * - Integrates with global state to execute commands
- *
- * CONVENTIONS
- * - Uses Zustand for state management
- * - Uses Dialog and Command components for UI
- * - Commands are registered in commandRegistry
- *
- * HOW TO USE
- * - Import and include <CommandPalette /> in the application root
- * - Use useCommandPaletteStore to control visibility
- * - Define commands in commandRegistry(registry.ts) with appropriate handlers
- * ------------------------------------------------------------
- */
-
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command";
+import { Badge } from "@/components/ui/badge";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandShortcut } from "@/components/ui/command";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-
 import { commandRegistry } from "@/commands/registry";
+import { displayShortcut, useShortcutStore } from "@/commands/shortcutStore";
 import { useCommandPaletteStore } from "@/store/commandPaletteStore";
 import { useAppStore } from "@/store/appShellStore";
 import { useTheme } from "@/components/ThemeProvider";
 import { useConnectDialogStore } from "@/store/canConnectDialogStore";
 import { useUiStore } from "@/store/uiStore";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 
 export function CommandPalette() {
-  const { open, closePalette } = useCommandPaletteStore();
+  const { open, openPalette, closePalette } = useCommandPaletteStore();
+  const shortcuts = useShortcutStore((s) => s.shortcuts);
   const setView = useAppStore((s) => s.setView);
   const { setTheme } = useTheme();
   const openConnectDialog = useConnectDialogStore((s) => s.openDialog);
   const openConnectionManager = useUiStore((s) => s.openConnectionManager);
+  const groupedCommands = commandRegistry.reduce<Record<string, typeof commandRegistry>>((groups, command) => {
+    const category = command.category ?? "Commands";
+    groups[category] ??= [];
+    groups[category].push(command);
+    return groups;
+  }, {});
 
   return (
-    <Dialog open={open} onOpenChange={closePalette}>
-      <DialogContent className="p-0">
-        {/* ✅ ACCESSIBILITY FIX */}
+    <Dialog open={open} onOpenChange={(nextOpen) => (nextOpen ? openPalette() : closePalette())}>
+      <DialogContent className="max-w-2xl overflow-hidden p-0">
         <VisuallyHidden>
-          <DialogTitle>Command Palette</DialogTitle>
-          <DialogDescription>Search and run application commands</DialogDescription>
-        </VisuallyHidden>{" "}
-        <Command>
-          <CommandInput placeholder="Type a command…" />
-          <CommandEmpty>No commands found.</CommandEmpty>
-
-          <CommandGroup heading="Commands">
-            {commandRegistry.map((cmd) => (
-              <CommandItem
-                key={cmd.id}
-                value={[cmd.title, ...(cmd.keywords ?? [])].join(" ")}
-                onSelect={() => {
-                  cmd.handler({ setView, setTheme, openConnectDialog, openConnectionManager });
-                  closePalette();
-                }}
-              >
-                {cmd.title}
-              </CommandItem>
+          <DialogTitle>Command Panel</DialogTitle>
+          <DialogDescription>Search and run application commands.</DialogDescription>
+        </VisuallyHidden>
+        <Command className="bg-background">
+          <div className="border-b bg-muted/30 px-4 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-semibold">Command Panel</div>
+                <div className="text-xs text-muted-foreground">Run actions, switch views, and open help surfaces.</div>
+              </div>
+              <Badge variant="outline">{displayShortcut(shortcuts, "app.commandPalette")}</Badge>
+            </div>
+          </div>
+          <CommandInput placeholder="Search commands, views, help, or connection actions" />
+          <CommandList className="max-h-[440px] p-2">
+            <CommandEmpty>No matching command.</CommandEmpty>
+            {Object.entries(groupedCommands).map(([category, commands]) => (
+              <CommandGroup key={category} heading={category}>
+                {commands.map((cmd) => (
+                  <CommandItem
+                    key={cmd.id}
+                    value={[cmd.title, cmd.description, ...(cmd.keywords ?? [])].filter(Boolean).join(" ")}
+                    className="items-start gap-3 rounded-md px-3 py-2"
+                    onSelect={() => {
+                      cmd.handler({ setView, setTheme, openConnectDialog, openConnectionManager, openPalette });
+                      closePalette();
+                    }}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium">{cmd.title}</div>
+                      {cmd.description && <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{cmd.description}</div>}
+                    </div>
+                    <CommandShortcut>{displayShortcut(shortcuts, cmd.id)}</CommandShortcut>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
             ))}
-          </CommandGroup>
+          </CommandList>
+          <div className="flex items-center justify-between border-t bg-muted/20 px-4 py-2 text-xs text-muted-foreground">
+            <span>Use arrow keys and Enter to run a command.</span>
+            <button
+              type="button"
+              className="rounded px-2 py-1 hover:bg-muted hover:text-foreground"
+              onClick={() => {
+                setView("shortcuts");
+                closePalette();
+              }}
+            >
+              Edit shortcuts
+            </button>
+          </div>
         </Command>
       </DialogContent>
     </Dialog>

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -18,8 +18,17 @@ import { AppCommand } from "./types";
 
 export const commandRegistry: AppCommand[] = [
   {
+    id: "app.commandPalette",
+    title: "Open Command Panel",
+    description: "Search commands, navigation, connection actions, and help.",
+    category: "Application",
+    keywords: ["command", "palette", "control", "panel"],
+    handler: ({ openPalette }) => openPalette(),
+  },
+  {
     id: "can.connect",
     title: "CAN: Connect",
+    description: "Open the connection dialog for local or remote capture.",
     category: "CAN",
     keywords: ["connect", "socketcan", "daemon"],
     handler: ({ openConnectDialog }) => openConnectDialog(),
@@ -27,6 +36,7 @@ export const commandRegistry: AppCommand[] = [
   {
     id: "can.manageConnections",
     title: "CAN: Manage Connections",
+    description: "Review saved local and remote connection entries.",
     category: "CAN",
     keywords: ["connect", "bridge", "daemon"],
     handler: ({ openConnectionManager }) => openConnectionManager(),
@@ -34,6 +44,7 @@ export const commandRegistry: AppCommand[] = [
   {
     id: "view.monitor",
     title: "View: CAN Monitor",
+    description: "Inspect live captures, loaded logs, filters, decoded preview, and transmit composer.",
     category: "View",
     keywords: ["monitor", "can", "rx"],
     handler: ({ setView }) => setView("monitor"),
@@ -41,6 +52,7 @@ export const commandRegistry: AppCommand[] = [
   {
     id: "view.simulator",
     title: "View: CAN Simulator",
+    description: "Open the transmit and simulation workspace.",
     category: "View",
     keywords: ["tx", "sim"],
     handler: ({ setView }) => setView("simulator"),
@@ -48,13 +60,23 @@ export const commandRegistry: AppCommand[] = [
   {
     id: "view.profileEditor",
     title: "View: Profile Editor",
+    description: "Edit message profile JSON through the visual profile editor.",
     category: "View",
     keywords: ["profile", "editor"],
     handler: ({ setView }) => setView("profile-editor"),
   },
   {
+    id: "view.settings",
+    title: "View: Settings",
+    description: "Configure appearance, density, and trace retention.",
+    category: "View",
+    keywords: ["settings", "appearance", "density"],
+    handler: ({ setView }) => setView("settings"),
+  },
+  {
     id: "theme.light",
     title: "Theme: Light",
+    description: "Use light appearance.",
     category: "Theme",
     keywords: ["light", "appearance"],
     handler: ({ setTheme }) => setTheme("light"),
@@ -62,6 +84,7 @@ export const commandRegistry: AppCommand[] = [
   {
     id: "theme.dark",
     title: "Theme: Dark",
+    description: "Use dark appearance.",
     category: "Theme",
     keywords: ["dark", "appearance"],
     handler: ({ setTheme }) => setTheme("dark"),
@@ -69,6 +92,7 @@ export const commandRegistry: AppCommand[] = [
   {
     id: "theme.system",
     title: "Theme: System",
+    description: "Follow the operating system appearance.",
     category: "Theme",
     keywords: ["system", "appearance"],
     handler: ({ setTheme }) => setTheme("system"),
@@ -76,8 +100,25 @@ export const commandRegistry: AppCommand[] = [
   {
     id: "help.user.documentation",
     title: "Help: User Documentation",
+    description: "Open the searchable help system.",
     category: "Help",
     keywords: ["help", "documentation", "support"],
     handler: ({ setView }) => setView("help"),
+  },
+  {
+    id: "help.shortcuts",
+    title: "Help: Keyboard Shortcuts",
+    description: "Review and edit keyboard shortcuts.",
+    category: "Help",
+    keywords: ["keyboard", "shortcuts", "hotkeys"],
+    handler: ({ setView }) => setView("shortcuts"),
+  },
+  {
+    id: "help.about",
+    title: "Help: About",
+    description: "Show product information and workspace capabilities.",
+    category: "Help",
+    keywords: ["about", "version", "info"],
+    handler: ({ setView }) => setView("about"),
   },
 ];

--- a/src/commands/shortcutStore.ts
+++ b/src/commands/shortcutStore.ts
@@ -1,0 +1,115 @@
+import { create } from "zustand";
+
+export const defaultShortcuts: Record<string, string> = {
+  "app.commandPalette": "Ctrl+Shift+P",
+  "view.monitor": "Ctrl+1",
+  "view.profileEditor": "Ctrl+2",
+  "view.settings": "Ctrl+,",
+  "help.user.documentation": "F1",
+  "help.shortcuts": "Ctrl+/",
+};
+
+type ShortcutState = {
+  shortcuts: Record<string, string>;
+  setShortcut: (commandId: string, shortcut: string) => void;
+  resetShortcut: (commandId: string) => void;
+  resetAllShortcuts: () => void;
+};
+
+const storageKey = "cansim.shortcuts.v1";
+
+function readStoredShortcuts() {
+  if (typeof window === "undefined") return {};
+  try {
+    const value = window.localStorage.getItem(storageKey);
+    return value ? (JSON.parse(value) as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredShortcuts(shortcuts: Record<string, string>) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(storageKey, JSON.stringify(shortcuts));
+}
+
+function normalizeShortcut(shortcut: string) {
+  return shortcut
+    .split("+")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (lower === "control") return "Ctrl";
+      if (lower === "cmd" || lower === "command" || lower === "meta") return "Meta";
+      if (lower === "option") return "Alt";
+      if (lower === "esc") return "Escape";
+      if (part.length === 1) return part.toUpperCase();
+      return part[0].toUpperCase() + part.slice(1);
+    })
+    .join("+");
+}
+
+export function formatShortcutFromEvent(event: Pick<KeyboardEvent, "ctrlKey" | "metaKey" | "altKey" | "shiftKey" | "key">) {
+  const key = event.key === " " ? "Space" : event.key;
+  const lowerKey = key.toLowerCase();
+  const parts = [
+    event.ctrlKey ? "Ctrl" : "",
+    event.metaKey ? "Meta" : "",
+    event.altKey ? "Alt" : "",
+    event.shiftKey ? "Shift" : "",
+  ].filter(Boolean);
+
+  if (!["control", "meta", "alt", "shift"].includes(lowerKey)) {
+    parts.push(key.length === 1 ? key.toUpperCase() : key);
+  }
+
+  return parts.join("+");
+}
+
+export function shortcutMatches(event: KeyboardEvent, shortcut: string) {
+  const normalized = normalizeShortcut(shortcut);
+  if (!normalized) return false;
+  return formatShortcutFromEvent(event) === normalized;
+}
+
+export function displayShortcut(shortcuts: Record<string, string>, commandId: string) {
+  return normalizeShortcut(shortcuts[commandId] ?? defaultShortcuts[commandId] ?? "");
+}
+
+export function shortcutConflicts(shortcuts: Record<string, string>) {
+  const active = { ...defaultShortcuts, ...shortcuts };
+  const seen = new Map<string, string>();
+  const conflicts = new Set<string>();
+  Object.entries(active).forEach(([commandId, shortcut]) => {
+    const normalized = normalizeShortcut(shortcut);
+    if (!normalized) return;
+    const existing = seen.get(normalized);
+    if (existing) {
+      conflicts.add(existing);
+      conflicts.add(commandId);
+    } else {
+      seen.set(normalized, commandId);
+    }
+  });
+  return conflicts;
+}
+
+export const useShortcutStore = create<ShortcutState>((set, get) => ({
+  shortcuts: readStoredShortcuts(),
+  setShortcut: (commandId, shortcut) => {
+    const shortcuts = { ...get().shortcuts, [commandId]: normalizeShortcut(shortcut) };
+    writeStoredShortcuts(shortcuts);
+    set({ shortcuts });
+  },
+  resetShortcut: (commandId) => {
+    const shortcuts = { ...get().shortcuts };
+    delete shortcuts[commandId];
+    writeStoredShortcuts(shortcuts);
+    set({ shortcuts });
+  },
+  resetAllShortcuts: () => {
+    writeStoredShortcuts({});
+    set({ shortcuts: {} });
+  },
+}));

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -14,18 +14,21 @@
  * - Commands should not directly manipulate UI components
  */
 
+import { AppView } from "@/store/appShellStore";
 import { Theme } from "@/components/ThemeProvider";
 
 export type CommandContext = {
-  setView: (view: any) => void;
+  setView: (view: AppView) => void;
   setTheme: (theme: Theme) => void;
   openConnectDialog: () => void;
   openConnectionManager: () => void;
+  openPalette: () => void;
 };
 
 export type AppCommand = {
   id: string;
   title: string;
+  description?: string;
   category?: string;
   keywords?: string[];
   shortcut?: string;

--- a/src/commands/useCommandPaletteHotkey.ts
+++ b/src/commands/useCommandPaletteHotkey.ts
@@ -18,21 +18,41 @@
  */
 import { useEffect } from "react";
 import { useCommandPaletteStore } from "@/store/commandPaletteStore";
+import { commandRegistry } from "@/commands/registry";
+import { defaultShortcuts, shortcutMatches, useShortcutStore } from "@/commands/shortcutStore";
+import { useAppStore } from "@/store/appShellStore";
+import { useTheme } from "@/components/ThemeProvider";
+import { useConnectDialogStore } from "@/store/canConnectDialogStore";
+import { useUiStore } from "@/store/uiStore";
+
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+  const tagName = target.tagName.toLowerCase();
+  return tagName === "input" || tagName === "textarea" || tagName === "select" || target.isContentEditable;
+}
 
 export function useCommandPaletteHotkey() {
-  const open = useCommandPaletteStore((s) => s.openPalette);
+  const openPalette = useCommandPaletteStore((s) => s.openPalette);
+  const closePalette = useCommandPaletteStore((s) => s.closePalette);
+  const paletteOpen = useCommandPaletteStore((s) => s.open);
+  const shortcuts = useShortcutStore((s) => s.shortcuts);
+  const setView = useAppStore((s) => s.setView);
+  const { setTheme } = useTheme();
+  const openConnectDialog = useConnectDialogStore((s) => s.openDialog);
+  const openConnectionManager = useUiStore((s) => s.openConnectionManager);
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
-      const isMac = navigator.platform.includes("Mac");
+      if (isEditableTarget(e.target) && !paletteOpen) return;
+      const command = commandRegistry.find((cmd) => shortcutMatches(e, shortcuts[cmd.id] ?? defaultShortcuts[cmd.id] ?? cmd.shortcut ?? ""));
+      if (!command) return;
 
-      if ((isMac && e.metaKey && e.shiftKey && e.key === "P") || (!isMac && e.ctrlKey && e.shiftKey && e.key === "P")) {
-        e.preventDefault();
-        open();
-      }
+      e.preventDefault();
+      command.handler({ setView, setTheme, openConnectDialog, openConnectionManager, openPalette });
+      if (paletteOpen && command.id !== "app.commandPalette") closePalette();
     }
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open]);
+  }, [closePalette, openConnectDialog, openConnectionManager, openPalette, paletteOpen, setTheme, setView, shortcuts]);
 }

--- a/src/components/help-system/defaultHelpMarkdown.ts
+++ b/src/components/help-system/defaultHelpMarkdown.ts
@@ -488,6 +488,29 @@ Keyboard behavior:
 - Shift+F3 moves to the previous result.
 - Escape clears the search field.
 
+## Keyboard shortcuts and command panel
+
+Open Help > Keyboard Shortcuts to review and edit application shortcuts. Click a shortcut field, press the new key combination, and the change is saved immediately for this installation.
+
+Default shortcuts:
+
+- Ctrl+Shift+P: open the command panel.
+- Ctrl+1: open CAN Monitor.
+- Ctrl+2: open Profile Editor.
+- Ctrl+,: open Settings.
+- Ctrl+/: open Keyboard Shortcuts.
+- F1: open Help.
+
+The command panel shows the same saved shortcuts beside each command and can also open the shortcut editor. Duplicate shortcuts are highlighted in the shortcut editor so they can be resolved before use.
+
+:::tip
+Use the command panel when you do not remember a shortcut. Search by action name, view name, connection workflow, theme, or help topic.
+:::
+
+## About screen
+
+Open Help > About to view application information, current appearance settings, and quick links back to the monitor and help system.
+
 ## Appearance settings
 
 Open Settings to change how the whole application looks and feels. Appearance changes apply immediately and are saved for the next session.

--- a/src/profile-editor/ProfileMessageEditor.tsx
+++ b/src/profile-editor/ProfileMessageEditor.tsx
@@ -122,6 +122,26 @@ function ensureCompactProfile(draft: CanProfile) {
   draft.attributes ??= [];
 }
 
+function definitionTitle(profile: CanProfile, node: ProfileNode) {
+  if (node.kind === "can-id") return "CAN ID layout";
+  if (node.kind === "service") return profile.service?.name ?? "Service";
+  if (node.kind === "payload-header") return "Payload header";
+  const attribute = selectedAttribute(profile, node);
+  const operation = selectedOperation(profile, node);
+  if (node.kind === "attribute") return attribute?.name ?? "Attribute";
+  if (node.kind === "operation") return operation?.type ?? "Operation";
+  return `${attribute?.name ?? "Attribute"} / ${operation?.type ?? "Operation"} / ${variantLabels[node.variant]}`;
+}
+
+function definitionNote(node: ProfileNode) {
+  if (node.kind === "can-id") return "Universal arbitration ID fields used before message matching.";
+  if (node.kind === "service") return "Profile-level service identity and byte order.";
+  if (node.kind === "payload-header") return "Shared payload header fields decoded for every matching frame.";
+  if (node.kind === "attribute") return "Attribute identity and operation list.";
+  if (node.kind === "operation") return "Feature index, operation name, and available direction variants.";
+  return "Payload fields for the selected message direction.";
+}
+
 export function ProfileMessageEditor() {
   const rawProfile = useProfileStore((s) => s.profile);
   const rawDraftProfile = useProfileStore((s) => s.draftProfile);
@@ -288,12 +308,18 @@ export function ProfileMessageEditor() {
 
   function addField() {
     updateProfile((draft) => {
-      const fields =
-        selectedNode.kind === "payload-header"
-          ? draft.payloadHeader?.fields
-          : selectedNode.kind === "variant"
-            ? draft.attributes?.[selectedNode.attributeIndex]?.operations?.[selectedNode.operationIndex]?.variants?.[selectedNode.variant]
-            : undefined;
+      let fields: PayloadFieldDef[] | undefined;
+      if (selectedNode.kind === "payload-header") {
+        draft.payloadHeader ??= { lengthBytes: 2, fields: [] };
+        draft.payloadHeader.fields ??= [];
+        fields = draft.payloadHeader.fields;
+      } else if (selectedNode.kind === "variant") {
+        const operation = draft.attributes?.[selectedNode.attributeIndex]?.operations?.[selectedNode.operationIndex];
+        if (!operation) return;
+        operation.variants ??= {};
+        operation.variants[selectedNode.variant] ??= [];
+        fields = operation.variants[selectedNode.variant];
+      }
       if (!fields) return;
       fields.push({
         name: `field_${fields.length + 1}`,
@@ -652,17 +678,21 @@ export function ProfileMessageEditor() {
   return (
     <div className="flex h-full min-h-0 gap-4 overflow-hidden">
       {renderOutline()}
-      <div className="min-h-0 min-w-[380px] flex-1 space-y-3 overflow-auto pb-8 pr-1">
-        <Card className="rounded-lg shadow-sm">
-          <CardHeader className="p-4 pb-2">
-            <CardTitle className="text-sm">Definition editor</CardTitle>
-          </CardHeader>
-          <CardContent className="pt-0 text-xs text-muted-foreground">
-            Renders directly from the compact JSON profile sections.
-          </CardContent>
-        </Card>
-        {renderDefinition()}
-      </div>
+      <Card className="flex min-h-0 min-w-[380px] flex-1 flex-col rounded-lg shadow-sm">
+        <CardHeader className="border-b p-4 pb-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-xs font-medium uppercase text-muted-foreground">Definition editor</div>
+              <CardTitle className="mt-1 text-sm">{definitionTitle(currentProfile, selectedNode)}</CardTitle>
+              <p className="mt-1 text-xs text-muted-foreground">{definitionNote(selectedNode)}</p>
+            </div>
+            {!editable && <Badge variant="outline">Read only</Badge>}
+          </div>
+        </CardHeader>
+        <CardContent className="min-h-0 flex-1 overflow-auto p-4 pb-8">
+          {renderDefinition()}
+        </CardContent>
+      </Card>
       <Card className="flex min-h-0 w-[360px] min-w-[300px] flex-col rounded-lg shadow-sm">
         <CardHeader className="p-4 pb-2">
           <CardTitle className="text-sm">Decoded preview</CardTitle>

--- a/src/store/appShellStore.ts
+++ b/src/store/appShellStore.ts
@@ -29,7 +29,7 @@
 import { create } from "zustand";
 
 // Define the possible main application views
-export type AppView = "monitor" | "simulator" | "profile-editor" | "settings" | "help";
+export type AppView = "monitor" | "simulator" | "profile-editor" | "settings" | "help" | "shortcuts" | "about";
 
 type SidebarMode = "expanded" | "icon";
 


### PR DESCRIPTION
## Summary
- Add About and Keyboard Shortcuts views under the Help menu.
- Add editable persisted shortcuts and show saved shortcut labels in the command panel.
- Improve the command panel layout and remove the top settings icon.
- Reshape the profile definition editor center pane and fix adding payload fields when a variant has no field array.

## Validation
- npx vite build